### PR TITLE
Update CI to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
- Update CI node version to 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)